### PR TITLE
Fix example in HOW_TO_USE.md

### DIFF
--- a/HOW_TO_USE.md
+++ b/HOW_TO_USE.md
@@ -27,7 +27,7 @@ fn basic_usage() {
   fs::write("test", "This is a test")?;
   assert_eq!(
     "This is a test",
-    &fs::read_to_string("test")?;
+    &fs::read_to_string("test")?
   );
 }
 ```


### PR DESCRIPTION
I was trying out the crate and got an error when copying the example because of the extra semicolon.