### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools", "development-tools::testing"]
 assay-proc-macro = { path = "assay-proc-macro", version = "0.1.0" }
 pretty_assertions = "^1.0.0"
 rusty-fork = "^0.3.0"
-tempdir = "^0.3.7"
+tempfile = "3.2.0"
 tokio = { version = "^1.16.0", features = ["rt-multi-thread"] }
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
   fs::{copy, create_dir_all},
   path::{Component, Path, PathBuf},
 };
-use tempdir::TempDir;
+use tempfile::{Builder, TempDir};
 
 #[doc(hidden)]
 pub struct PrivateFS {
@@ -41,7 +41,7 @@ pub struct PrivateFS {
 impl PrivateFS {
   pub fn new() -> Result<Self, Box<dyn Error>> {
     let ran_from = env::current_dir()?;
-    let directory = TempDir::new("private")?;
+    let directory = Builder::new().prefix("private").tempdir()?;
     env::set_current_dir(directory.path())?;
     Ok(Self {
       ran_from,


### PR DESCRIPTION
Since tempdir crate is deprecated it should get replaced with tempfile.
Have build and ran tests successfully.