### PR TITLE
Use NEXTEST_EXECUTION_MODE rather than NEXTEST to detect process-per-test mode

### DIFF
--- a/assay-proc-macro/src/lib.rs
+++ b/assay-proc-macro/src/lib.rs
@@ -200,10 +200,10 @@ pub fn assay(attr: TokenStream, item: TokenStream) -> TokenStream {
           }
         }
 
-      if std::env::var("NEXTEST")
+      if std::env::var("NEXTEST_EXECUTION_MODE")
         .ok()
         .as_ref()
-        .map(|s| s.as_str() == "1")
+        .map(|s| s.as_str() == "process-per-test")
         .unwrap_or(false)
       {
         child();


### PR DESCRIPTION
I added this to leave open the possibility that in the future, nextest
gains the ability to have multiple tests per process. See
<https://nexte.st/book/env-vars#environment-variables-nextest-sets> for
more information.