### PR TITLE
Add support for async-std and make async optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,21 @@ jobs:
           override: true
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
-      - name: Lint (clippy)
+      - name: Lint (clippy) async-std
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features --all-targets
+          args: --no-default-features --features async-std-runtime --all-targets
+      - name: Lint (clippy) tokio
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features --features async-tokio-runtime --all-targets
+      - name: Lint (clippy) default
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets
       - name: Lint (rustfmt)
         uses: actions-rs/cargo@v1
         with:
@@ -56,24 +66,54 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           override: true
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
-      # cargo test
-      - name: Build all targets with all features
+      # cargo build
+      - name: Build all targets with default features
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets --all-features
-      - name: Test with cargo test
+          args: --all-targets
+      - name: Build all targets with async-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets --no-default-features --features async-std-runtime
+      - name: Build all targets with tokio
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets --no-default-features --features async-tokio-runtime
+      - name: Test async-std with cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --workspace
+          args: --workspace --no-default-features --features async-std-runtime
+      - name: Test tokio with cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --no-default-features --features async-tokio-runtime
+      - name: Test defaults with cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
       # cargo nextest
       - name: Install nextest from crates.io
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-nextest
-      - name: Test with nextest from crates.io
+      - name: Test async-std with nextest from crates.io
         uses: actions-rs/cargo@v1
         with:
           command: nextest
-          args: run --all-features
+          args: run --no-default-features --features async-std-runtime
+      - name: Test tokio with nextest from crates.io
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run --no-default-features --features async-tokio-runtime
+      - name: Test defaults with nextest from crates.io
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,17 @@ keywords = ["proc-macro", "test", "testing"]
 categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
-assay-proc-macro = { path = "assay-proc-macro", version = "0.1.0" }
+assay-proc-macro = { path = "assay-proc-macro", version = "0.1.0", default-features = false }
+async-std = { version = "^1.10.0", optional = true }
 pretty_assertions_sorted = "^1.0.0"
 rusty-fork = "^0.3.0"
 tempfile = "3.2.0"
-tokio = { version = "^1.16.0", features = ["rt-multi-thread"] }
+tokio = { version = "^1.16.0", features = ["rt-multi-thread"], optional = true }
 
 [workspace]
 members = ["assay-proc-macro"]
+
+[features]
+default = ["async-tokio-runtime"]
+async-tokio-runtime = ["tokio", "assay-proc-macro/async"]
+async-std-runtime = ["async-std", "assay-proc-macro/async"]

--- a/HOW_TO_USE.md
+++ b/HOW_TO_USE.md
@@ -15,6 +15,23 @@ Then importing the macro for your tests:
 use assay::assay;
 ```
 
+This setup will by default turn on the ability for `async` tests using `tokio`, if you wish to turn
+it off to cut down on dependencies then you can do the following:
+
+```toml
+[dev-dependencies]
+assay = {version = "0.1.0", no-default-features = true }
+```
+
+`assay` also supports using the `async-std` runtime if you prefer instead of
+`tokio` which can be enabled as such:
+
+```toml
+[dev-dependencies]
+assay = {version = "0.1.0", no-default-features = true, features =
+"async-std-runtime" }
+```
+
 ### Basic Usage & Automatic Niceties
 
 Just putting on the `#[assay]` attribute is the easiest way to get started:
@@ -108,8 +125,9 @@ fn panic_test() {
 
 ### `async` tests
 If you want your tests to run `async` code all you need to do is specify that the
-test is `async`. Note this won't let you control the runtime currently. `assay` only
-uses the default `tokio` executor.
+test is `async`. `assay` defaults to using `tokio` as the executor, but can use `async-std`.
+Note: you cannot use the `async` functionality if `no-default-features` is enabled in your
+`Cargo.toml` with no specified runtime.
 
 ```rust
 use assay::assay;

--- a/assay-proc-macro/Cargo.toml
+++ b/assay-proc-macro/Cargo.toml
@@ -17,3 +17,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
+
+[features]
+default = ["async"]
+async = []

--- a/assay-proc-macro/src/lib.rs
+++ b/assay-proc-macro/src/lib.rs
@@ -161,12 +161,14 @@ pub fn assay(attr: TokenStream, item: TokenStream) -> TokenStream {
   let asyncness = sig.asyncness.take();
   let block = func.block;
   let body = if asyncness.is_some() {
+    #[cfg(not(feature = "async"))]
+    compile_error!("You cannot use the async functionality in `assay` without specifiying a runtime. This error is occurring because you turned off the default features. Possible feature values are:\n- async-tokio-runtime\n- async-std-runtime");
     quote! {
       async fn inner_async() -> Result<(), Box<dyn std::error::Error>> {
         #block
         Ok(())
       }
-      assay::Runtime::new()?.block_on(inner_async())?;
+      assay::async_runtime::Runtime::block_on(inner_async())??;
     }
   } else {
     quote! { #block }


### PR DESCRIPTION
This commit adds the ability to turn off async functionality by setting
`no-default-features = true` in your `Cargo.toml` for `assay`. This
means if you don't need the async functionality it won't bring in
`tokio` by default reducing compile times. We also add support for
`async-std` by setting `no-default-features = true, features =
["async-std-runtime"]` in your `Cargo.toml` for `assay`. Functionally
this doesn't change how `assay` works and lets you choose another
runtime for your code. Useful if you depend on functionality of a
specific runtime. It has been orchestrated to make it easier to choose
one of the two with feature flags while not breaking existing
functionality.

Closes #8