### PR TITLE
File inclusion with an explicit destination path

### DIFF
--- a/assay-proc-macro/src/lib.rs
+++ b/assay-proc-macro/src/lib.rs
@@ -51,11 +51,15 @@ impl Parse for AssayAttribute {
                 }) => {
                   let value = lit_str.value();
                   Some((value, None))
-                },
+                }
                 Expr::Tuple(tuple) => {
                   let mut elements = Vec::new();
                   for e in tuple.elems.into_iter() {
-                    if let Expr::Lit(ExprLit { lit: Lit::Str(lit_str), ..}) = e {
+                    if let Expr::Lit(ExprLit {
+                      lit: Lit::Str(lit_str),
+                      ..
+                    }) = e
+                    {
                       elements.push(lit_str.value());
                     } else {
                       // TODO: Should we return a parsing error to the user here? How?
@@ -134,8 +138,8 @@ pub fn assay(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     for (source_path, destination_path) in include {
       let destination_fragment = match destination_path {
-        None => quote!(std::option::Option::None),
-        Some(p) => quote!(std::option::Option::Some(#p))
+        None => quote!(std::option::Option::<::std::path::PathBuf>::None),
+        Some(p) => quote!(std::option::Option::Some(#p)),
       };
       out = quote! {
         #out

--- a/assay-proc-macro/src/lib.rs
+++ b/assay-proc-macro/src/lib.rs
@@ -62,14 +62,12 @@ impl Parse for AssayAttribute {
                     {
                       elements.push(lit_str.value());
                     } else {
-                      // TODO: Should we return a parsing error to the user here? How?
                       return None;
                     }
                   }
                   if elements.len() == 2 {
                     Some((elements[0].clone(), Some(elements[1].clone())))
                   } else {
-                    // TODO: Should we return a parsing error to the user here? How?
                     None
                   }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ pub use rusty_fork::{fork, rusty_fork_id, rusty_fork_test_name, ChildWrapper};
 use std::{
   env,
   error::Error,
-  fs::{copy, create_dir_all},
-  path::{Component, Path, PathBuf},
+  fs::{copy},
+  path::{Path, PathBuf},
 };
 use tempfile::{Builder, TempDir};
 
@@ -61,25 +61,11 @@ impl PrivateFS {
     // Get our working directory
     let dir = self.directory.path().to_owned();
 
-    // Make the relative path of the file in relation to our temp file
-    // system based on if it was absolute or not
-    let relative = if !is_relative {
-      inner_path
-        .components()
-        .filter(|c| *c != Component::RootDir)
-        .collect::<PathBuf>()
-    } else {
-      path.as_ref().into()
-    };
-
-    // If the relative path to the file includes parent directories create
-    // them
-    if let Some(parent) = relative.parent() {
-      create_dir_all(dir.join(parent))?;
-    }
-
     // Copy the file over from the file system into the temp file system
-    copy(inner_path, dir.join(relative))?;
+    // We mount all included files in the root directory of the test's private filesystem
+    // TODO: return meaningful error message
+    let filename = inner_path.file_name().unwrap().to_owned();
+    copy(inner_path, dir.join(filename))?;
 
     Ok(())
   }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -33,7 +33,7 @@ fn private_2() {
 
 #[assay(include = ["Cargo.toml", "src/lib.rs"])]
 fn include() {
-  assert!(fs::metadata("src/lib.rs")?.is_file());
+  assert!(fs::metadata("lib.rs")?.is_file());
   assert!(fs::metadata("Cargo.toml")?.is_file());
 }
 
@@ -110,7 +110,7 @@ async fn one_test_to_call_it_all() {
   assert_eq!(env::var("BADDOGS")?, "false");
   assert_eq!(fs::read_to_string("setup")?, "Value: 5");
   assert!(PathBuf::from("Cargo.toml").exists());
-  assert!(PathBuf::from("src/lib.rs").exists());
+  assert!(PathBuf::from("lib.rs").exists());
 
   // Removing this actually causes the test to fail
   panic!();
@@ -133,7 +133,7 @@ async fn one_test_to_call_it_all_2() {
   assert_eq!(env::var("BADDOGS")?, "false");
   assert_eq!(fs::read_to_string("setup")?, "Value: 5");
   assert!(PathBuf::from("Cargo.toml").exists());
-  assert!(PathBuf::from("src/lib.rs").exists());
+  assert!(PathBuf::from("lib.rs").exists());
 
   // Removing this actually causes the test to fail
   panic!();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -96,7 +96,7 @@ fn setup_teardown_test_2() {
 
 #[assay(
   setup = setup_func_2(),
-  include = ["Cargo.toml", "src/lib.rs"],
+  include = ["Cargo.toml", ("src/lib.rs", "src/lib.rs")],
   env = [
     ("GOODBOY", "Bukka"),
     ("BADDOGS", "false")
@@ -111,7 +111,7 @@ async fn one_test_to_call_it_all() {
   assert_eq!(env::var("BADDOGS")?, "false");
   assert_eq!(fs::read_to_string("setup")?, "Value: 5");
   assert!(PathBuf::from("Cargo.toml").exists());
-  assert!(PathBuf::from("lib.rs").exists());
+  assert!(PathBuf::from("src/lib.rs").exists());
 
   // Removing this actually causes the test to fail
   panic!();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -31,10 +31,11 @@ fn private_2() {
   assert_eq!("This is a test\nprivate 2\n", &fs::read_to_string("test")?);
 }
 
-#[assay(include = ["Cargo.toml", "src/lib.rs"])]
+#[assay(include = ["Cargo.toml", "src/lib.rs", ("HOW_TO_USE.md", "docs/GUIDE.md")])]
 fn include() {
   assert!(fs::metadata("lib.rs")?.is_file());
   assert!(fs::metadata("Cargo.toml")?.is_file());
+  assert!(fs::metadata("docs/GUIDE.md")?.is_file());
 }
 
 #[assay(should_panic)]


### PR DESCRIPTION
As discussed in #9, this PR changes the behaviour of the `include` attribute:

- `#[assay(include = ["folder/my_file.rs"])` will copy the file into the root folder of the test working directory (i.e. `file.rs`);
- `#[assay(include = [("folder/my_file.rs", "folder/my_renamed_file.rs"])` will instead use the specified destination path.

I have a few questions on the implementation that I've left as TODO comment in the code. I'd appreciate your input there.

Closes #9 