### PR TITLE
Support ignored tests

### DIFF
--- a/assay-proc-macro/src/lib.rs
+++ b/assay-proc-macro/src/lib.rs
@@ -165,6 +165,7 @@ pub fn assay(attr: TokenStream, item: TokenStream) -> TokenStream {
 
   // Parse the function out into individual parts
   let func = parse_macro_input!(item as ItemFn);
+  let attrs = func.attrs;
   let vis = func.vis;
   let mut sig = func.sig;
   let name = sig.ident.clone();
@@ -188,6 +189,7 @@ pub fn assay(attr: TokenStream, item: TokenStream) -> TokenStream {
       #[test]
       #should_panic
       #ignore
+      #(#attrs)*
       #vis #sig {
         fn modify(_: &mut std::process::Command) {}
 

--- a/assay-proc-macro/src/lib.rs
+++ b/assay-proc-macro/src/lib.rs
@@ -16,6 +16,7 @@ use syn::{
 struct AssayAttribute {
   include: Option<Vec<String>>,
   should_panic: bool,
+  ignore: bool,
   env: Option<Vec<(String, String)>>,
   setup: Option<Expr>,
   teardown: Option<Expr>,
@@ -25,6 +26,7 @@ impl Parse for AssayAttribute {
   fn parse(input: ParseStream) -> Result<Self> {
     let mut include = None;
     let mut should_panic = false;
+    let mut ignore = false;
     let mut env = None;
     let mut setup = None;
     let mut teardown = None;
@@ -55,6 +57,7 @@ impl Parse for AssayAttribute {
           );
         }
         "should_panic" => should_panic = true,
+        "ignore" => ignore = true,
         "env" => {
           let _: Token![=] = input.parse()?;
           let array: ExprArray = input.parse()?;
@@ -97,6 +100,7 @@ impl Parse for AssayAttribute {
     Ok(AssayAttribute {
       include,
       should_panic,
+      ignore,
       env,
       setup,
       teardown,
@@ -127,6 +131,12 @@ pub fn assay(attr: TokenStream, item: TokenStream) -> TokenStream {
 
   let should_panic = if attr.should_panic {
     quote! { #[should_panic] }
+  } else {
+    quote! {}
+  };
+
+  let ignore = if attr.ignore {
+    quote! { #[ignore] }
   } else {
     quote! {}
   };
@@ -177,6 +187,7 @@ pub fn assay(attr: TokenStream, item: TokenStream) -> TokenStream {
   let expanded = quote! {
       #[test]
       #should_panic
+      #ignore
       #vis #sig {
         fn modify(_: &mut std::process::Command) {}
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -165,3 +165,9 @@ impl Future for ReadyOnPoll {
 fn should_be_ignored() {
   panic!("this test should be ignored")
 }
+
+#[assay]
+#[should_panic]
+fn respects_other_attributes() {
+  panic!("this test is expected to panic");
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -160,3 +160,8 @@ impl Future for ReadyOnPoll {
     Poll::Ready(())
   }
 }
+
+#[assay(ignore)]
+fn should_be_ignored() {
+  panic!("this test should be ignored")
+}


### PR DESCRIPTION
This PR adds a new argument `ignore` to the attribute macro, which expands into an `#[ignore]` attribute on the generated test function. A minimal test for this functionality is included, but no tests for the interaction with other arguments or features yet.

Additionally, this PR includes attributes specified on the input function in the generated test function. If you'd like, I can break this functionality out into its own PR.

With the second change, it should also be possible to remove the first change and deprecate the `should_panic` argument in favor of specifying `#[ignore]` or `#[should_panic]` directly.

Fixes #12 