### PR TITLE
Remove rusty_fork in favor of handrolled solution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,10 @@ categories = ["development-tools", "development-tools::testing"]
 
 [dependencies]
 assay-proc-macro = { path = "assay-proc-macro", version = "0.1.0", default-features = false }
-async-std = { version = "^1.10.0", optional = true }
-pretty_assertions_sorted = "^1.0.0"
-rusty-fork = "^0.3.0"
-tempfile = "3.2.0"
-tokio = { version = "^1.16.0", features = ["rt-multi-thread"], optional = true }
+async-std = { version = "^1.13.0", optional = true }
+pretty_assertions_sorted = "^1.2.3"
+tempfile = "3.14.0"
+tokio = { version = "^1.41.1", features = ["rt-multi-thread"], optional = true }
 
 [workspace]
 members = ["assay-proc-macro"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,6 @@
 pub use assay_proc_macro::assay;
 #[doc(hidden)]
 pub use pretty_assertions_sorted::{assert_eq, assert_eq_sorted, assert_ne};
-#[doc(hidden)]
-pub use rusty_fork::{fork, rusty_fork_id, rusty_fork_test_name, ChildWrapper};
 
 use std::{
   env,

--- a/test.py
+++ b/test.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S uv run
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["termcolor == 2.5"]
+# ///
+
+from subprocess import run, DEVNULL
+from sys import exit
+from termcolor import colored
+
+passing_tests = run(["cargo", "test", "--workspace"])
+failing_tests = run(
+    ["cargo", "test", "--workspace", "--", "--ignored"], stdout=DEVNULL, stderr=DEVNULL
+)
+
+passing_tests.check_returncode()
+if failing_tests.returncode == 0:
+    print(
+        colored("ERROR: ", "red")
+        + "Ignored tests failed to fail properly. Forking of assay processes is broken somehow"
+    )
+    print(
+        colored("HINT: ", "cyan")
+        + "run the tests with 'cargo test --workspace -- --ignored' to see what failed"
+    )
+    exit(1)

--- a/tests/should_fail.rs
+++ b/tests/should_fail.rs
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 Michael Gattozzi <self@mgattozzi.dev>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Inverted tests that we *want* to panic or pass. Given assay causes a test
+//! to spawn itself we need to make sure these tests can actually properly fail.
+//! We run these as part of a script to actually call them. Mainly because these
+//! test that the assay macro works and if a test fails or does not it works as
+//! expected. These are all ignored by default and must be explicitly called for
+//! if we want them to run. This is because we expect these to fail and so we need
+//! to run commands to check for a failure output for CI purposes
+
+use assay::assay;
+
+#[assay(ignore)]
+fn should_panic_and_cause_a_failure_case() {
+  panic!()
+}
+
+#[assay(ignore, should_panic)]
+fn should_not_panic_and_cause_a_failure_case() {}


### PR DESCRIPTION
This commit changes up how the assay macro works by forking the code into it's Command process instead of using rusty_fork which did the same thing under the hood. rusty_fork is both outdated and not the most ergonomic to work with. With these changes our handrolled solution is a bit easier to work with as a library author and makes it easier for us to make sure tests fail the way we expect and capture that output properly. In order to support this feature we also:

- Added support for the ignore attribute in assay
- Added a python script to run the main test suite and two tests we expect to fail so that we know the Command forking actually works
- Upgraded the dependencies to more modern versions since it has been 2 years since the last commit

Closes #12
Closes #3